### PR TITLE
Improve guard server tracking stripping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Contribution Guidelines
+
+- Run `pytest -q` before committing to ensure all tests pass.
+- The repository uses `pylint` for linting. Run `pylint -E detrackify_email.py` and address any errors.
+- Prefer small, focused commits with descriptive messages.
+- Documentation lives in `README.md` and `GUARD_SERVER.md`.
+- For new features, update documentation and add tests where appropriate.

--- a/GUARD_SERVER.md
+++ b/GUARD_SERVER.md
@@ -36,12 +36,15 @@ Optional parameters:
 * `--resource-dir` Directory containing additional resources (images only)
 * `--timeout` Seconds to wait before the continue button activates (default `5`)
 * `--privacy` Disable logging of visited links
-* `--resolve` Resolve the final URL before showing the continue button
+* `--resolve` Resolve the final URL before showing the continue button (uses HEAD)
 * `--resolve-cache-file` File used to store resolved URLs
 * `--resolve-cache-days` Days to keep cached items (default `30`)
 * `--resolve-cache-max` Maximum number of cached items (default `4096`)
-* `--resolve-get` Use HTTP GET instead of HEAD when resolving links
+* `--resolve-get` Use HTTP GET when resolving links (implies `--resolve`)
+* `--strip-param-prefix` Remove tracking parameters starting with PREFIX and everything after (may be used multiple times)
 
+The `--strip-param-prefix` option is useful for removing marketing parameters such as `utm_source`. The first matching parameter and all subsequent parameters are dropped from the URL before displaying it or performing the redirect.
+Removing parameters may break links if any subsequent parameter is required by the destination site.
 
 The server verifies the provided hash, shows a warning page and then redirects the
 user without sending a referrer header. It automatically chooses a warning page
@@ -50,11 +53,12 @@ Spanish, French, Chinese and Arabic are included; if no matching template exists
 the English version is used. These translations were generated automatically so
 minor errors may exist.
 
-When `--resolve` is enabled the server will attempt to determine the final
-destination of the provided link. By default it performs a series of HEAD
-requests but if `--resolve-get` is used it will download the full page via GET
-and extract its title. The page will display a progress message while this
-happens and the continue button activates only once the real URL is known. The
+When link resolution is enabled the server will attempt to determine the final
+destination of the provided link. By default a series of HEAD requests is issued
+but `--resolve-get` switches to GET requests and also extracts the page title.
+Using `--resolve-get` implicitly enables resolution even when `--resolve` is not
+specified. The page will display a progress message while this happens and the
+continue button activates only once the real URL is known. The
 result is cached in memory and optionally persisted to a JSON file to speed up
 future requests.
 Using `--resolve-get` downloads the full page, which may consume significantly

--- a/README.md
+++ b/README.md
@@ -63,9 +63,14 @@ options:
 See the [guard server guide](GUARD_SERVER.md) for more details on running the guard server, enabling privacy mode and using a reverse proxy.
 Links that already point to the guard server are skipped so messages cannot rewrite an already-guarded link. This safety check cannot be disabled.
 The guard server can optionally resolve links before showing the continue button.
-Resolving normally uses HTTP HEAD requests but can be switched to GET to also
-show the page title. Using GET downloads the entire page and may trigger
-tracking on the remote site.
+Resolving normally uses HTTP HEAD requests but `--resolve-get` enables resolution
+via HTTP GET (this flag also implies `--resolve`). Using GET downloads the entire
+page and may trigger tracking on the remote site.
+Tracking parameters can be stripped from URLs with
+`--strip-param-prefix PREFIX`. For example `--strip-param-prefix utm_` removes the
+first parameter beginning with `utm_` and everything following it. The option may
+be specified multiple times for different prefixes. Removing parameters may break
+links if later parameters are required by the target site.
 Per-request settings are delivered via `/guard/opts.js` so the main
 `/guard/common.js` file can be cached by browsers.
 

--- a/detrackify_guard.py
+++ b/detrackify_guard.py
@@ -22,7 +22,8 @@ import re
 import time
 import threading
 import atexit
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+import urllib.parse
 
 import requests
 from bs4 import BeautifulSoup
@@ -53,6 +54,7 @@ class GuardConfig:
     cache_days: int = 30
     cache_max: int = 4096
     resolve_get: bool = False
+    strip_param_prefixes: list[str] = field(default_factory=list)
 
 
 class ResolveCache:
@@ -125,17 +127,18 @@ class GuardServer:
         self.timeout = config.timeout
         self.resource_dir = config.resource_dir
         self.privacy = config.privacy
-        self.resolve_enabled = config.resolve
+        self.resolve_enabled = config.resolve or config.resolve_get
         self.resolve_get = config.resolve_get
+        self.strip_prefixes = list(config.strip_param_prefixes)
         self.cache = (
             ResolveCache(config.cache_max, config.cache_days, config.cache_file)
-            if config.resolve
+            if self.resolve_enabled
             else None
         )
 
         self.app.add_url_rule('/guard/<sha>/<data>', 'guard', self.guard,
                               methods=['GET', 'POST'])
-        if config.resolve:
+        if self.resolve_enabled:
             self.app.add_url_rule('/guard/resolve', 'resolve', self.resolve_link,
                                   methods=['POST'])
             self.app.add_url_rule('/guard/go', 'go', self.go, methods=['POST'])
@@ -173,6 +176,27 @@ class GuardServer:
         """Validate hash for payload."""
         calc = hashlib.sha1((payload + self.salt).encode()).hexdigest()
         return calc == sent_sha
+
+    def strip_query_params(self, url: str) -> str:
+        """Remove query parameters starting with configured prefixes."""
+        if not self.strip_prefixes or not url:
+            return url
+        try:
+            parts = urllib.parse.urlsplit(url)
+        except Exception:  # pylint: disable=broad-except
+            return url
+        if not parts.query:
+            return url
+        params = parts.query.split("&")
+        keep = []
+        for param in params:
+            key = param.split("=")[0]
+            if any(key.startswith(p) for p in self.strip_prefixes):
+                break
+            keep.append(param)
+        new_query = "&".join(p for p in keep if p)
+        parts = parts._replace(query=new_query)
+        return urllib.parse.urlunsplit(parts)
 
     def resource(self, filename):
         """Serve optional resource files."""
@@ -244,7 +268,7 @@ class GuardServer:
             try:
                 decoded = base64.urlsafe_b64decode(data).decode()
                 info = json.loads(decoded)
-                target = info.get('url', '')
+                target = self.strip_query_params(info.get('url', ''))
             except Exception:  # pylint: disable=broad-except
                 abort(400)
             url = target
@@ -252,7 +276,7 @@ class GuardServer:
             try:
                 if self.resolve_get:
                     resp = requests.get(target, allow_redirects=True, timeout=self.timeout)
-                    url = resp.url
+                    url = self.strip_query_params(resp.url)
                     try:
                         soup = BeautifulSoup(resp.text, 'html.parser')
                         if soup.title and soup.title.string:
@@ -261,7 +285,7 @@ class GuardServer:
                         pass
                 else:
                     resp = requests.head(target, allow_redirects=True, timeout=self.timeout)
-                    url = resp.url
+                    url = self.strip_query_params(resp.url)
             except Exception as exc:  # pylint: disable=broad-except
                 logging.exception('Failed to resolve %s', target)
                 return jsonify({'error': str(exc)}), 500
@@ -274,7 +298,7 @@ class GuardServer:
         """Redirect using a resolved URL."""
         if not self.resolve_enabled:
             abort(404)
-        url = request.form.get('url', '')
+        url = self.strip_query_params(request.form.get('url', ''))
         sha = request.form.get('sha', '')
         try:
             start = float(request.form.get('ts', '0'))
@@ -314,6 +338,7 @@ class GuardServer:
             except ValueError:
                 start = 0.0
             elapsed = time.time() - start
+            target_url = self.strip_query_params(info.get('url'))
             if not self.privacy:
                 if elapsed < self.timeout:
                     logging.warning("Link activated too quickly: %.2fs < %ds", elapsed, self.timeout)
@@ -322,7 +347,7 @@ class GuardServer:
                     if info.get('to'):
                         logging.info(
                             "Redirecting to %s (%s) for %s after %.2fs",
-                            info.get('url'),
+                            target_url,
                             display,
                             info.get('to'),
                             elapsed,
@@ -330,16 +355,16 @@ class GuardServer:
                     else:
                         logging.info(
                             "Redirecting to %s (%s) after %.2fs",
-                            info.get('url'),
+                            target_url,
                             display,
                             elapsed,
                         )
-            resp = redirect(info.get('url'), code=302)
+            resp = redirect(target_url, code=302)
             resp.headers['Referrer-Policy'] = 'no-referrer'
             return resp
 
         start = time.time()
-        url = info.get('url', '')
+        url = self.strip_query_params(info.get('url', ''))
         valid = bool(url)
         if not valid:
             url = 'Missing or invalid URL'
@@ -379,7 +404,9 @@ def main():
     parser.add_argument('--resolve-cache-max', type=int, default=4096,
                         help='Maximum number of cached entries (default 4096)')
     parser.add_argument('--resolve-get', action='store_true',
-                        help='Use HTTP GET instead of HEAD when resolving')
+                        help='Use HTTP GET when resolving links (implies --resolve)')
+    parser.add_argument('--strip-param-prefix', action='append', default=[],
+                        help='Strip query parameters starting with PREFIX and everything after')
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
@@ -390,16 +417,17 @@ def main():
         template_dir=args.template_dir,
         resource_dir=args.resource_dir,
         privacy=args.privacy,
-        resolve=args.resolve,
+        resolve=args.resolve or args.resolve_get,
         cache_file=args.resolve_cache_file,
         cache_days=args.resolve_cache_days,
         cache_max=args.resolve_cache_max,
         resolve_get=args.resolve_get,
+        strip_param_prefixes=args.strip_param_prefix,
     )
     server = GuardServer(config)
     if args.privacy:
         logging.info('Privacy Mode Enabled; no logging of email address, link, domain, or recipient will happen')
-    if args.resolve:
+    if args.resolve or args.resolve_get:
         atexit.register(server.cache.close)
     server.app.run(host=args.listen_ip, port=args.listen_port)
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -10,6 +10,8 @@ import base64
 import json
 import hashlib
 from bs4 import BeautifulSoup
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import detrackify_guard
 
 # Path to the script under test
 SCRIPT = os.path.join(os.path.dirname(os.path.dirname(__file__)), "detrackify_email.py")
@@ -232,3 +234,56 @@ def test_guard_via_config_file():
     payload = json.loads(base64.urlsafe_b64decode(b64).decode())
     assert payload.get("to") == "dest@example.com"
     assert msg["X-Detrackify-Guard-Mode"] == "mismatch"
+
+
+def test_strip_query_params():
+    cfg = detrackify_guard.GuardConfig(
+        salt="x",
+        strip_param_prefixes=["utm_"]
+    )
+    server = detrackify_guard.GuardServer(cfg)
+    url = server.strip_query_params("https://example.com/?a=1&utm_source=x&b=2")
+    assert url == "https://example.com/?a=1"
+
+
+def test_strip_query_params_no_match():
+    cfg = detrackify_guard.GuardConfig(
+        salt="x",
+        strip_param_prefixes=["utm_"]
+    )
+    server = detrackify_guard.GuardServer(cfg)
+    url = server.strip_query_params("https://example.com/?a=1&b=2")
+    assert url == "https://example.com/?a=1&b=2"
+
+
+def test_strip_query_params_multiple_prefixes():
+    cfg = detrackify_guard.GuardConfig(
+        salt="x",
+        strip_param_prefixes=["foo", "utm_"]
+    )
+    server = detrackify_guard.GuardServer(cfg)
+    url = server.strip_query_params("https://example.com/?a=1&foo_id=2&utm_x=3&b=4")
+    assert url == "https://example.com/?a=1"
+
+
+def test_resolve_get_registers_routes():
+    cfg = detrackify_guard.GuardConfig(
+        salt="x",
+        resolve=False,
+        resolve_get=True
+    )
+    server = detrackify_guard.GuardServer(cfg)
+    rules = {r.rule for r in server.app.url_map.iter_rules()}
+    assert "/guard/resolve" in rules
+    assert "/guard/go" in rules
+
+
+def test_resolve_get_enables_resolution():
+    cfg = detrackify_guard.GuardConfig(
+        salt="x",
+        resolve=False,
+        resolve_get=True
+    )
+    server = detrackify_guard.GuardServer(cfg)
+    assert server.resolve_enabled is True
+    assert server.resolve_get is True


### PR DESCRIPTION
## Summary
- add query stripping in guard server via `--strip-param-prefix`
- make `--resolve-get` imply link resolution
- support optional prefixes for stripping and handle `utm_*`
- document new options and behaviour
- add CONTRIBUTING notes in `AGENTS.md`
- test query stripping and resolve-get logic
- fix route registration when using `--resolve-get`
- document caveats for stripping parameters

## Testing
- `pytest -q`
- `pylint -E detrackify_email.py detrackify_guard.py`


------
https://chatgpt.com/codex/tasks/task_e_6864cf881b348320aefc7c08018b48da