### PR TITLE
Highlight original link domain in guard resolve view

### DIFF
--- a/templates/common.js
+++ b/templates/common.js
@@ -210,6 +210,12 @@ document.addEventListener('DOMContentLoaded', function () {
         addUrlTooltip(urlEl);
     }
 
+    // Highlight original link shown during resolution
+    var originalUrlEls = document.getElementsByClassName('original-url');
+    Array.prototype.forEach.call(originalUrlEls, function(el) {
+        el.innerHTML = highlightAsPhishing(el.textContent);
+    });
+
     // Function to add tooltips to all URL elements
     function applyUrlTooltips() {
         // Find all URL elements that might need tooltips

--- a/templates/guard_warning.html
+++ b/templates/guard_warning.html
@@ -51,7 +51,7 @@
         <div class="url-transition">
           <div class="url-original">
             <span class="url-label">Original link:</span>
-            <span class="url-value noselect">{{ url }}</span>
+            <span class="url-value noselect original-url">{{ url }}</span>
           </div>
           <div class="url-arrow">→</div>
           <div class="url-resolved">
@@ -70,7 +70,7 @@
         <div class="url-transition">
           <div class="url-original">
             <span class="url-label">Original link:</span>
-            <span class="url-value noselect">{{ url }}</span>
+            <span class="url-value noselect original-url">{{ url }}</span>
           </div>
           <div class="url-arrow">→</div>
           <div class="url-resolved">

--- a/templates/guard_warning_ar.html
+++ b/templates/guard_warning_ar.html
@@ -52,7 +52,7 @@
         <div class="url-transition">
           <div class="url-original">
             <span class="url-label">الرابط الأصلي:</span>
-            <span class="url-value noselect">{{ url }}</span>
+            <span class="url-value noselect original-url">{{ url }}</span>
           </div>
           <div class="url-arrow">→</div>
           <div class="url-resolved">
@@ -71,7 +71,7 @@
         <div class="url-transition">
           <div class="url-original">
             <span class="url-label">الرابط الأصلي:</span>
-            <span class="url-value noselect">{{ url }}</span>
+            <span class="url-value noselect original-url">{{ url }}</span>
           </div>
           <div class="url-arrow">→</div>
           <div class="url-resolved">

--- a/templates/guard_warning_da.html
+++ b/templates/guard_warning_da.html
@@ -52,7 +52,7 @@
         <div class="url-transition">
           <div class="url-original">
             <span class="url-label">Originalt link:</span>
-            <span class="url-value noselect">{{ url }}</span>
+            <span class="url-value noselect original-url">{{ url }}</span>
           </div>
           <div class="url-arrow">→</div>
           <div class="url-resolved">
@@ -71,7 +71,7 @@
         <div class="url-transition">
           <div class="url-original">
             <span class="url-label">Originalt link:</span>
-            <span class="url-value noselect">{{ url }}</span>
+            <span class="url-value noselect original-url">{{ url }}</span>
           </div>
           <div class="url-arrow">→</div>
           <div class="url-resolved">

--- a/templates/guard_warning_de.html
+++ b/templates/guard_warning_de.html
@@ -52,7 +52,7 @@
         <div class="url-transition">
           <div class="url-original">
             <span class="url-label">Originaler Link:</span>
-            <span class="url-value noselect">{{ url }}</span>
+            <span class="url-value noselect original-url">{{ url }}</span>
           </div>
           <div class="url-arrow">→</div>
           <div class="url-resolved">
@@ -71,7 +71,7 @@
         <div class="url-transition">
           <div class="url-original">
             <span class="url-label">Originaler Link:</span>
-            <span class="url-value noselect">{{ url }}</span>
+            <span class="url-value noselect original-url">{{ url }}</span>
           </div>
           <div class="url-arrow">→</div>
           <div class="url-resolved">

--- a/templates/guard_warning_es.html
+++ b/templates/guard_warning_es.html
@@ -52,7 +52,7 @@
         <div class="url-transition">
           <div class="url-original">
             <span class="url-label">Enlace original:</span>
-            <span class="url-value noselect">{{ url }}</span>
+            <span class="url-value noselect original-url">{{ url }}</span>
           </div>
           <div class="url-arrow">→</div>
           <div class="url-resolved">
@@ -71,7 +71,7 @@
         <div class="url-transition">
           <div class="url-original">
             <span class="url-label">Enlace original:</span>
-            <span class="url-value noselect">{{ url }}</span>
+            <span class="url-value noselect original-url">{{ url }}</span>
           </div>
           <div class="url-arrow">→</div>
           <div class="url-resolved">

--- a/templates/guard_warning_fr.html
+++ b/templates/guard_warning_fr.html
@@ -52,7 +52,7 @@
         <div class="url-transition">
           <div class="url-original">
             <span class="url-label">Lien original :</span>
-            <span class="url-value noselect">{{ url }}</span>
+            <span class="url-value noselect original-url">{{ url }}</span>
           </div>
           <div class="url-arrow">→</div>
           <div class="url-resolved">
@@ -71,7 +71,7 @@
         <div class="url-transition">
           <div class="url-original">
             <span class="url-label">Lien original :</span>
-            <span class="url-value noselect">{{ url }}</span>
+            <span class="url-value noselect original-url">{{ url }}</span>
           </div>
           <div class="url-arrow">→</div>
           <div class="url-resolved">

--- a/templates/guard_warning_sv.html
+++ b/templates/guard_warning_sv.html
@@ -52,7 +52,7 @@
         <div class="url-transition">
           <div class="url-original">
             <span class="url-label">Original länk:</span>
-            <span class="url-value noselect">{{ url }}</span>
+            <span class="url-value noselect original-url">{{ url }}</span>
           </div>
           <div class="url-arrow">→</div>
           <div class="url-resolved">
@@ -71,7 +71,7 @@
         <div class="url-transition">
           <div class="url-original">
             <span class="url-label">Original länk:</span>
-            <span class="url-value noselect">{{ url }}</span>
+            <span class="url-value noselect original-url">{{ url }}</span>
           </div>
           <div class="url-arrow">→</div>
           <div class="url-resolved">

--- a/templates/guard_warning_zh.html
+++ b/templates/guard_warning_zh.html
@@ -52,7 +52,7 @@
         <div class="url-transition">
           <div class="url-original">
             <span class="url-label">原始链接：</span>
-            <span class="url-value noselect">{{ url }}</span>
+            <span class="url-value noselect original-url">{{ url }}</span>
           </div>
           <div class="url-arrow">→</div>
           <div class="url-resolved">
@@ -71,7 +71,7 @@
         <div class="url-transition">
           <div class="url-original">
             <span class="url-label">原始链接：</span>
-            <span class="url-value noselect">{{ url }}</span>
+            <span class="url-value noselect original-url">{{ url }}</span>
           </div>
           <div class="url-arrow">→</div>
           <div class="url-resolved">

--- a/tests/test_guard_original_link_highlight.py
+++ b/tests/test_guard_original_link_highlight.py
@@ -1,0 +1,29 @@
+import jinja2
+import pytest
+
+TEMPLATES = [
+    'guard_warning.html',
+    'guard_warning_ar.html',
+    'guard_warning_de.html',
+    'guard_warning_fr.html',
+    'guard_warning_es.html',
+    'guard_warning_sv.html',
+    'guard_warning_da.html',
+    'guard_warning_zh.html',
+]
+
+@pytest.mark.parametrize('template_name', TEMPLATES)
+def test_original_url_has_highlight_class(template_name):
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader('templates'))
+    template = env.get_template(template_name)
+    html = template.render(
+        url='https://malicious.example',
+        display='https://good.example',
+        domain='good.example',
+        block_reason='',
+        resolve=True,
+        ts=0,
+        sender_email=None,
+        sender_display=None,
+    )
+    assert 'class="url-value noselect original-url"' in html

--- a/tests/test_param_stripping.py
+++ b/tests/test_param_stripping.py
@@ -223,7 +223,7 @@ class TestParameterStripping(unittest.TestCase):
         from bs4 import BeautifulSoup
         
         # Create a fake image tag with no tracking parameters
-        html = '<img src="https://example.com/image.png?param1=value1&param2=value2" />'
+        html = '<img src="https://example.com/image.png?param1=value1&amp;param2=value2" />'
         soup = BeautifulSoup(html, 'html.parser')
         img_tag = soup.find('img')
         
@@ -275,9 +275,9 @@ class TestParameterStripping(unittest.TestCase):
         html = '''
         <html>
         <body>
-            <img src="https://example.com/image1.png?param1=value1&utm_source=test&param2=value2" width="200" height="150" />
-            <img src="https://example.com/image2.png?param1=value1&param2=value2" width="200" height="150" />
-            <img src="https://example.com/image3.png?fbclid=12345&param1=value1" width="200" height="150" />
+            <img src="https://example.com/image1.png?param1=value1&amp;utm_source=test&amp;param2=value2" width="200" height="150" />
+            <img src="https://example.com/image2.png?param1=value1&amp;param2=value2" width="200" height="150" />
+            <img src="https://example.com/image3.png?fbclid=12345&amp;param1=value1" width="200" height="150" />
         </body>
         </html>
         '''


### PR DESCRIPTION
## Summary
- Emphasize the original link's domain during link resolution by tagging it with an `original-url` class across guard warning templates
- Extend client script to apply phishing-style highlighting to those spans
- Fix parameter stripping tests to use valid HTML and add a regression test verifying the highlight class

## Testing
- `python -m pylint -E detrackify_email.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2201cce588320a163d9f925e11b52